### PR TITLE
abits and qbits code for quest tracking

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -27,7 +27,7 @@ L_FLAGS = $(PROF) $(SOLARIS_LINK) -lz $(NEED_DL)
 D_FLAGS = -g2 -O $(PROF) $(SOLARIS_LINK)
 
 C_FILES = agemobcomm.c agecommand.c act_comm.c act_info.c act_move.c act_obj.c act_wiz.c ban.c boards.c \
-          bank.c build.c calendar.c clans.c color.c comm.c comments.c const.c db.c deity.c \
+          bank.c bits.c build.c calendar.c clans.c color.c comm.c comments.c const.c db.c deity.c \
           dns.c fight.c handler.c hashstr.c hint.c hotboot.c house.c imm_host.c interp.c \
           liquids.c magic.c makeobjs.c mapout.c mapper.c mccp.c \
           misc.c mpxset.c mssp.c mud_comm.c mud_prog.c news.c planes.c player.c polymorph.c \

--- a/src/bits.c
+++ b/src/bits.c
@@ -1,0 +1,803 @@
+/* bits.c -- Abits and Qbits for the Rogue Winds by Scion
+   Copyright 2000 by Peter Keeler, All Rights Reserved. The content
+   of this file may be used by anyone for any purpose so long as this
+   original header remains entirely intact and credit is given to the
+   original author(s).
+
+   The concept for this was inspired by Mallory's mob scripting system
+   from AntaresMUD.
+
+   It is not required, but I'd appreciate hearing back from people
+   who use this code. What are you using it for, what have you done
+   to it, ideas, comments, etc. So while it's not necessary, I'd love
+   to get a note from you at scion@divineright.org. Thanks! -- Scion
+*/
+
+#include <stdio.h>
+#include "mud.h"
+
+/* These are the ends of the linked lists that store the mud's library of valid bits. */
+BIT_DATA *first_abit;
+BIT_DATA *last_abit;
+
+BIT_DATA *first_qbit;
+BIT_DATA *last_qbit;
+
+/* QBITS save, ABITS do not save. There are enough of each to give a range
+   of them to builders the same as their vnums. They are identifiable by mobs
+   running mob progs, and can be used as little identifiers for players..
+   player X has done this and this and this.. think of them like a huge array
+   of boolean variables you can put on a player or mob with a mob prog. -- Scion
+*/
+
+void free_abit( BIT_DATA * abit )
+{
+   UNLINK( abit, first_abit, last_abit, next, prev );
+   DISPOSE( abit );
+   return;
+}
+
+void free_qbit( BIT_DATA * qbit )
+{
+   UNLINK( qbit, first_qbit, last_qbit, next, prev );
+   DISPOSE( qbit );
+   return;
+}
+
+void free_questbits( void )
+{
+   BIT_DATA *abit, *abit_next, *qbit, *qbit_next;
+
+   for( abit = first_abit; abit; abit = abit_next )
+   {
+      abit_next = abit->next;
+      free_abit( abit );
+   }
+
+   for( qbit = first_qbit; qbit; qbit = qbit_next )
+   {
+      qbit_next = qbit->next;
+      free_qbit( qbit );
+   }
+   return;
+}
+
+/* Find an abit in the mud's listing */
+BIT_DATA *find_abit( int number )
+{
+   BIT_DATA *bit;
+
+   for( bit = first_abit; bit; bit = bit->next )
+   {
+      if( bit->number == number )
+         return bit;
+   }
+   return NULL;
+}
+
+/* Find a qbit in the mud's listing */
+BIT_DATA *find_qbit( int number )
+{
+   BIT_DATA *bit;
+
+   for( bit = first_qbit; bit; bit = bit->next )
+   {
+      if( bit->number == number )
+         return bit;
+   }
+   return NULL;
+}
+
+/* Find an abit on a character and return it */
+BIT_DATA *get_abit( CHAR_DATA * ch, int number )
+{
+   BIT_DATA *bit = NULL;
+
+   for( bit = ch->first_abit; bit; bit = bit->next )
+   {
+      if( bit->number == number )
+         return bit;
+   }
+   return NULL;
+}
+
+/* Find a qbit on a character and return it */
+BIT_DATA *get_qbit( CHAR_DATA * ch, int number )
+{
+   BIT_DATA *bit = NULL;
+
+   if( IS_NPC( ch ) )
+      return NULL;
+
+   for( bit = ch->pcdata->first_qbit; bit; bit = bit->next )
+   {
+      if( bit->number == number )
+         return bit;
+   }
+   return NULL;
+}
+
+/* Write out the abit and qbit files */
+void save_bits( void )
+{
+   BIT_DATA *start_bit;
+   BIT_DATA *bit;
+   FILE *fpout;
+   char filename[256];
+   int mode = 0;
+
+   /*
+    * Print 2 files 
+    */
+   for( mode = 0; mode < 2; mode++ )
+   {
+      if( mode == 0 )
+      {
+         snprintf( filename, 256, "%sabit.lst", SYSTEM_DIR );
+         start_bit = first_abit;
+      }
+      else
+      {
+         snprintf( filename, 256, "%sqbit.lst", SYSTEM_DIR );
+         start_bit = first_qbit;
+      }
+
+      if( ( fpout = fopen( filename, "w" ) ) == NULL )
+      {
+         bug( "Cannot open bit list %d for writing", mode );
+         return;
+      }
+
+      for( bit = start_bit; bit; bit = bit->next )
+      {
+         fprintf( fpout, "Number	%d\n", bit->number );
+         fprintf( fpout, "Desc	%s~\n", bit->desc );
+         fprintf( fpout, "%s", "End\n\n" );
+      }
+      fprintf( fpout, "%s", "#END\n" );
+      fclose( fpout );
+      fpout = NULL;
+   }
+}
+
+/* Load the abits and qbits */
+void load_bits( void )
+{
+   char buf[256];
+   const char *word;
+   bool fMatch;
+   int mode = 0;
+   BIT_DATA *bit = NULL;
+   FILE *fp;
+
+   snprintf( buf, 256, "%sabit.lst", SYSTEM_DIR );
+   if( ( fp = fopen( buf, "r" ) ) == NULL )
+   {
+      perror( buf );
+      return;
+   }
+
+   for( ;; )
+   {
+      word = feof( fp ) ? "End" : fread_word( fp );
+      fMatch = FALSE;
+
+      switch ( UPPER( word[0] ) )
+      {
+         case '*':
+            fMatch = TRUE;
+            fread_to_eol( fp );
+            break;
+
+         case '#':
+            if( !str_cmp( word, "#END" ) )
+            {
+               fclose( fp );
+               fp = NULL;
+               if( mode == 0 )
+               {
+                  mode = 1;   /* We have two files to read, I reused the same code to read both */
+                  snprintf( buf, 256, "%sqbit.lst", SYSTEM_DIR );
+                  if( ( fp = fopen( buf, "r" ) ) == NULL )
+                  {
+                     perror( buf );
+                     return;
+                  }
+               }
+               else
+                  return;
+               fMatch = TRUE;
+            }
+            break;
+
+         case 'D':
+            if( !str_cmp( word, "Desc" ) )
+            {
+               fMatch = TRUE;
+               mudstrlcpy( bit->desc, fread_flagstring( fp ), MAX_STRING_LENGTH );
+            }
+            break;
+
+         case 'E':
+            if( !str_cmp( word, "End" ) )
+            {
+               if( mode == 0 )
+                  LINK( bit, first_abit, last_abit, next, prev );
+               else
+                  LINK( bit, first_qbit, last_qbit, next, prev );
+               bit = NULL;
+               fMatch = TRUE;
+            }
+            break;
+
+         case 'N':
+            if( !str_cmp( word, "Number" ) )
+            {
+               CREATE( bit, BIT_DATA, 1 );
+               bit->number = fread_number( fp );
+               fMatch = TRUE;
+            }
+            break;
+      }
+      if( !fMatch )
+         bug( "%s: no match: %s", __FUNCTION__, word );
+   }
+}
+
+/* Add an abit to a character */
+void set_abit( CHAR_DATA * ch, int number )
+{
+   BIT_DATA *bit;
+   BIT_DATA *proto_bit;
+
+   if( number < 0 || number > MAX_xBITS )
+      return;
+
+   for( proto_bit = first_abit; proto_bit; proto_bit = proto_bit->next )
+   {
+      if( proto_bit->number == number )
+         break;
+   }
+
+   if( proto_bit == NULL )
+      return;
+
+   if( ( bit = get_abit( ch, number ) ) == NULL )
+   {
+      CREATE( bit, BIT_DATA, 1 );
+
+      bit->number = proto_bit->number;
+      mudstrlcpy( bit->desc, proto_bit->desc, MAX_STRING_LENGTH );
+      LINK( bit, ch->first_abit, ch->last_abit, next, prev );
+   }
+}
+
+/* Add a qbit to a character */
+void set_qbit( CHAR_DATA * ch, int number )
+{
+   BIT_DATA *bit;
+   BIT_DATA *proto_bit;
+
+   if( IS_NPC( ch ) )
+      return;
+
+   if( number < 0 || number > MAX_xBITS )
+      return;
+
+   for( proto_bit = first_qbit; proto_bit; proto_bit = proto_bit->next )
+   {
+      if( proto_bit->number == number )
+         break;
+   }
+
+   if( proto_bit == NULL )
+      return;
+
+   if( ( bit = get_qbit( ch, number ) ) == NULL )
+   {
+      CREATE( bit, BIT_DATA, 1 );
+
+      bit->number = proto_bit->number;
+      mudstrlcpy( bit->desc, proto_bit->desc, MAX_STRING_LENGTH );
+      LINK( bit, ch->pcdata->first_qbit, ch->pcdata->last_qbit, next, prev );
+   }
+}
+
+/* Take an abit off a character */
+void remove_abit( CHAR_DATA * ch, int number )
+{
+   BIT_DATA *bit, *bit_next;
+
+   if( number < 0 || number > MAX_xBITS )
+      return;
+
+   if( !ch->first_abit )
+      return;
+
+   for( bit = ch->first_abit; bit; bit = bit_next )
+   {
+      bit_next = bit->next;
+
+      if( bit->number == number )
+      {
+         UNLINK( bit, ch->first_abit, ch->last_abit, next, prev );
+         DISPOSE( bit );
+      }
+   }
+}
+
+/* Take a qbit off a character */
+void remove_qbit( CHAR_DATA * ch, int number )
+{
+   BIT_DATA *bit, *bit_next;
+
+   if( IS_NPC( ch ) )
+      return;
+
+   if( number < 0 || number > MAX_xBITS )
+      return;
+
+   if( !ch->pcdata->first_qbit )
+      return;
+
+   for( bit = ch->pcdata->first_qbit; bit; bit = bit_next )
+   {
+      bit_next = bit->next;
+
+      if( bit->number == number )
+      {
+         UNLINK( bit, ch->pcdata->first_qbit, ch->pcdata->last_qbit, next, prev );
+         DISPOSE( bit );
+      }
+   }
+}
+
+/* Show an abit from the mud's linked list, or all of them if 'all' is the argument */
+void do_showabit( CHAR_DATA * ch, char *argument )
+{
+   int number;
+   BIT_DATA *bit;
+
+   if( !first_abit )
+   {
+      send_to_char( "There are no Abits defined.\n\r", ch );
+      return;
+   }
+
+   if( !str_cmp( argument, "all" ) )
+   {
+      for( bit = first_abit; bit; bit = bit->next )
+         ch_printf( ch, "&RABIT: &Y%d &G%s\n\r", bit->number, bit->desc );
+      return;
+   }
+
+   number = atoi( argument );
+
+   if( number < 0 || number > MAX_xBITS )
+      return;
+
+   for( bit = first_abit; bit; bit = bit->next )
+   {
+      if( bit->number == number )
+         break;
+   }
+
+   if( bit == NULL )
+   {
+      send_to_char( "That abit does not exist.\n\r", ch );
+      return;
+   }
+
+   ch_printf( ch, "&RABIT: &Y%d\n\r", bit->number );
+   ch_printf( ch, "&G%s\n\r", bit->desc );
+}
+
+/* Show a qbit from the mud's linked list or all of them if 'all' is the argument */
+void do_showqbit( CHAR_DATA * ch, char *argument )
+{
+   int number;
+   BIT_DATA *bit;
+
+   if( !first_qbit )
+   {
+      send_to_char( "There are no Qbits defined.\n\r", ch );
+      return;
+   }
+
+   if( !str_cmp( argument, "all" ) )
+   {
+      for( bit = first_qbit; bit; bit = bit->next )
+         ch_printf( ch, "&RQBIT: &Y%d &G%s\n\r", bit->number, bit->desc );
+      return;
+   }
+
+   number = atoi( argument );
+
+   if( number < 0 || number > MAX_xBITS )
+      return;
+
+   for( bit = first_qbit; bit; bit = bit->next )
+   {
+      if( bit->number == number )
+         break;
+   }
+
+   if( bit == NULL )
+   {
+      send_to_char( "That qbit does not exist.\n\r", ch );
+      return;
+   }
+
+   ch_printf( ch, "&RQBIT: &Y%d\n\r", bit->number );
+   ch_printf( ch, "&G %s\n\r", bit->desc );
+}
+
+/* setabit <number> <desc> */
+/* Set the description for a particular abit */
+void do_setabit( CHAR_DATA * ch, char *argument )
+{
+   BIT_DATA *bit;
+   int number;
+   char arg[MAX_INPUT_LENGTH];
+
+   argument = one_argument( argument, arg );
+
+   if( !arg || arg[0] == '\0' )
+   {
+      send_to_char( "You must supply a bit number!\n\r", ch );
+      return;
+   }
+
+   if( !is_number( arg ) )
+   {
+      send_to_char( "You must specify a numerical bit value.\n\r", ch );
+      return;
+   }
+   number = atoi( arg );
+
+   if( !argument || argument[0] == '\0' )
+   {
+      send_to_char( "You must supply a description, or \"delete\" if you wish to delete.\n\r", ch );
+      return;
+   }
+
+   mudstrlcpy( arg, argument, MAX_INPUT_LENGTH );
+
+   if( number < 0 || number > MAX_xBITS )
+   {
+      send_to_char( "That is not a valid number for an abit.\n\r", ch );
+      return;
+   }
+
+   if( !arg || arg[0] == '\0' )
+   {
+      send_to_char( "Syntax: setabit <number> <description>\n\r", ch );
+      send_to_char( "Syntax: setabit <number> delete\n\r", ch );
+      return;
+   }
+
+   for( bit = first_abit; bit; bit = bit->next )
+   {
+      if( bit->number == number )
+         break;
+   }
+
+   if( !str_cmp( arg, "delete" ) && bit )
+   {
+      free_abit( bit );
+      ch_printf( ch, "Abit %d has been destroyed.\n\r", number );
+      save_bits(  );
+      return;
+   }
+
+   if( bit == NULL )
+   {
+      CREATE( bit, BIT_DATA, 1 );
+      bit->number = number;
+      mudstrlcpy( bit->desc, arg, MAX_STRING_LENGTH );
+      LINK( bit, first_abit, last_abit, next, prev );
+      ch_printf( ch, "Abit %d created.\n\r", bit->number );
+   }
+   ch_printf( ch, "Description for abit %d set to '%s'.\n\r", bit->number, bit->desc );
+
+   save_bits(  );
+}
+
+/* setqbit <number> <desc> */
+/* Set the description for a particular qbit */
+void do_setqbit( CHAR_DATA * ch, char *argument )
+{
+   BIT_DATA *bit;
+   int number;
+   char arg[MAX_INPUT_LENGTH];
+
+   argument = one_argument( argument, arg );
+
+   if( !arg || arg[0] == '\0' )
+   {
+      send_to_char( "You must supply a bit number!\n\r", ch );
+      return;
+   }
+
+   if( !is_number( arg ) )
+   {
+      send_to_char( "You must specify a numerical bit value.\n\r", ch );
+      return;
+   }
+   number = atoi( arg );
+
+   if( !argument || argument[0] == '\0' )
+   {
+      send_to_char( "You must supply a description, or \"delete\" if you wish to delete.\n\r", ch );
+      return;
+   }
+
+   mudstrlcpy( arg, argument, MAX_INPUT_LENGTH );
+
+   if( number < 0 || number > MAX_xBITS )
+   {
+      send_to_char( "That is not a valid number for a qbit.\n\r", ch );
+      return;
+   }
+
+   if( !arg || arg[0] == '\0' )
+   {
+      send_to_char( "Syntax: setqbit <number> <description>\n\r", ch );
+      send_to_char( "Syntax: setqbit <number> delete\n\r", ch );
+      return;
+   }
+
+   for( bit = first_qbit; bit; bit = bit->next )
+   {
+      if( bit->number == number )
+         break;
+   }
+
+   if( !str_cmp( arg, "delete" ) && bit )
+   {
+      free_qbit( bit );
+      ch_printf( ch, "Qbit %d has been destroyed.\n\r", number );
+      save_bits(  );
+      return;
+   }
+
+   if( bit == NULL )
+   {
+      CREATE( bit, BIT_DATA, 1 );
+      bit->number = number;
+      mudstrlcpy( bit->desc, arg, MAX_STRING_LENGTH );
+      LINK( bit, first_qbit, last_qbit, next, prev );
+      ch_printf( ch, "Qbit %d created.\n\r", bit->number );
+   }
+   ch_printf( ch, "Description for qbit %d set to '%s'.\n\r", bit->number, bit->desc );
+
+   save_bits(  );
+}
+
+/* Imm command to toggle an abit on a character or to list the abits already on a character */
+void do_abit( CHAR_DATA * ch, char *argument )
+{
+   BIT_DATA *bit;
+   char buf[MAX_STRING_LENGTH];
+   CHAR_DATA *victim;
+
+   argument = one_argument( argument, buf );
+
+   if( !buf || buf[0] == '\0' )
+   {
+      send_to_char( "Whose bits do you want to examine?\n\r", ch );
+      return;
+   }
+
+   if( ( victim = get_char_world( ch, buf ) ) == NULL )
+   {
+      send_to_char( "They are not in the game.\n\r", ch );
+      return;
+   }
+
+   argument = one_argument( argument, buf );
+
+   if( !buf || buf[0] == '\0' )
+   {
+      if( !victim->first_abit )
+      {
+         send_to_char( "They have no abits set on them.\n\r", ch );
+         return;
+      }
+
+      ch_printf( ch, "&RABITS for %s:\n\r", IS_NPC( victim ) ? victim->short_descr : victim->name );
+
+      for( bit = victim->first_abit; bit; bit = bit->next )
+         ch_printf( ch, "&Y%4.4d: &G%s\n\r", bit->number, bit->desc );
+   }
+   else
+   {
+      int abit;
+
+      abit = atoi( buf );
+
+      if( abit < 0 || abit > MAX_xBITS )
+      {
+         send_to_char( "That is an invalid abit number.\n\r", ch );
+         return;
+      }
+
+      if( get_abit( victim, abit ) != NULL )
+      {
+         remove_abit( victim, abit );
+         ch_printf( ch, "Removed abit %d from %s.\n\r", abit, IS_NPC( victim ) ? victim->short_descr : victim->name );
+      }
+      else
+      {
+         set_abit( victim, abit );
+         ch_printf( ch, "Added abit %d to %s.\n\r", abit, IS_NPC( victim ) ? victim->short_descr : victim->name );
+      }
+   }
+}
+
+/* Immortal command to toggle a qbit on a character or to list the qbits already on a character */
+void do_qbit( CHAR_DATA * ch, char *argument )
+{
+   BIT_DATA *bit;
+   CHAR_DATA *victim;
+   char buf[MAX_STRING_LENGTH];
+
+   argument = one_argument( argument, buf );
+
+   if( !buf || buf[0] == '\0' )
+   {
+      send_to_char( "Whose bits do you want to examine?\n\r", ch );
+      return;
+   }
+
+   if( ( victim = get_char_world( ch, buf ) ) == NULL )
+   {
+      send_to_char( "They are not in the game.\n\r", ch );
+      return;
+   }
+
+   if( IS_NPC( victim ) )
+   {
+      send_to_char( "NPCs cannot have qbits.\n\r", ch );
+      return;
+   }
+
+   argument = one_argument( argument, buf );
+
+   if( !buf || buf[0] == '\0' )
+   {
+      if( !victim->pcdata->first_qbit )
+      {
+         send_to_char( "They do not have any qbits.\n\r", ch );
+         return;
+      }
+
+      ch_printf( ch, "&RQBITS for %s:\n\r", victim->name );
+
+      for( bit = victim->pcdata->first_qbit; bit; bit = bit->next )
+         ch_printf( ch, "&Y%4.4d: &G%s\n\r", bit->number, bit->desc );
+   }
+   else
+   {
+      int qbit;
+
+      qbit = atoi( buf );
+
+      if( qbit < 0 || qbit > MAX_xBITS )
+      {
+         send_to_char( "That is an invalid qbit number.\n\r", ch );
+         return;
+      }
+
+      if( get_qbit( victim, qbit ) != NULL )
+      {
+         remove_qbit( victim, qbit );
+         ch_printf( ch, "Removed qbit %d from %s.\n\r", qbit, victim->name );
+      }
+      else
+      {
+         set_qbit( victim, qbit );
+         ch_printf( ch, "Added qbit %d to %s.\n\r", qbit, victim->name );
+      }
+   }
+}
+
+/* mpaset <char> */
+/* Mob prog version of do_abit */
+/* Don't use this with death_progs or anything else that has the potential for the target to
+ * be in another room. If the target will be in a different location after the prog, set the
+ * bit BEFORE they move.
+ */
+void do_mpaset( CHAR_DATA * ch, char *argument )
+{
+   char arg1[MAX_INPUT_LENGTH];
+   char arg2[MAX_INPUT_LENGTH];
+   CHAR_DATA *victim;
+   int number;
+
+   if( !IS_NPC( ch ) || ch->desc || IS_AFFECTED( ch, AFF_CHARM ) )
+   {
+      send_to_char( "Huh?\n\r", ch );
+      return;
+   }
+
+   argument = one_argument( argument, arg1 );
+   argument = one_argument( argument, arg2 );
+
+   if( !arg1 || arg1[0] == '\0' )
+   {
+      progbug( "Mpaset: missing victim", ch );
+      return;
+   }
+
+   if( !arg2 || arg2[0] == '\0' )
+   {
+      progbug( "Mpaset: missing bit", ch );
+      return;
+   }
+
+   if( !( victim = get_char_room( ch, arg1 ) ) )
+   {
+      progbug( "Mpaset: victim not in room", ch );
+      return;
+   }
+
+   number = atoi( arg2 );
+   if( get_abit( victim, number ) != NULL )
+      remove_abit( victim, number );
+   else
+      set_abit( victim, number );
+}
+
+/* mpqset <char> */
+/* Mob prog version of do_qbit */
+/* Because this can be used on death_progs, be SURE your victim is correct or you could
+ * end up setting a bit on the wrong person. Use 0.$n as your victim target in progs.
+ */
+void do_mpqset( CHAR_DATA * ch, char *argument )
+{
+   char arg1[MAX_INPUT_LENGTH];
+   char arg2[MAX_INPUT_LENGTH];
+   CHAR_DATA *victim;
+   int number;
+
+   if( !IS_NPC( ch ) || ch->desc || IS_AFFECTED( ch, AFF_CHARM ) )
+   {
+      send_to_char( "Huh?\n\r", ch );
+      return;
+   }
+
+   argument = one_argument( argument, arg1 );
+   argument = one_argument( argument, arg2 );
+
+   if( !arg1 || arg1[0] == '\0' )
+   {
+      progbug( "Mpqset: missing victim", ch );
+      return;
+   }
+
+   if( !arg2 || arg2[0] == '\0' )
+   {
+      progbug( "Mpqset: missing bit", ch );
+      return;
+   }
+
+   if( !( victim = get_char_world( ch, arg1 ) ) )
+   {
+      progbug( "Mpqset: victim not in game", ch );
+      return;
+   }
+
+   if( IS_NPC( victim ) )
+   {
+      progbug( "Mpqset: setting Qbit on NPC", ch );
+      return;
+   }
+
+   number = atoi( arg2 );
+   if( get_qbit( victim, number ) != NULL )
+      remove_qbit( victim, number );
+   else
+      set_qbit( victim, number );
+}
+

--- a/src/bits.c
+++ b/src/bits.c
@@ -353,7 +353,7 @@ void remove_qbit( CHAR_DATA * ch, int number )
 }
 
 /* Show an abit from the mud's linked list, or all of them if 'all' is the argument */
-void do_showabit( CHAR_DATA * ch, char *argument )
+void do_showabit( CHAR_DATA * ch, const char *argument )
 {
    int number;
    BIT_DATA *bit;
@@ -393,7 +393,7 @@ void do_showabit( CHAR_DATA * ch, char *argument )
 }
 
 /* Show a qbit from the mud's linked list or all of them if 'all' is the argument */
-void do_showqbit( CHAR_DATA * ch, char *argument )
+void do_showqbit( CHAR_DATA * ch, const char *argument )
 {
    int number;
    BIT_DATA *bit;
@@ -434,7 +434,7 @@ void do_showqbit( CHAR_DATA * ch, char *argument )
 
 /* setabit <number> <desc> */
 /* Set the description for a particular abit */
-void do_setabit( CHAR_DATA * ch, char *argument )
+void do_setabit( CHAR_DATA * ch, const char *argument )
 {
    BIT_DATA *bit;
    int number;
@@ -442,7 +442,7 @@ void do_setabit( CHAR_DATA * ch, char *argument )
 
    argument = one_argument( argument, arg );
 
-   if( !arg || arg[0] == '\0' )
+   if(  arg[0] == '\0' )
    {
       send_to_char( "You must supply a bit number!\n\r", ch );
       return;
@@ -469,7 +469,7 @@ void do_setabit( CHAR_DATA * ch, char *argument )
       return;
    }
 
-   if( !arg || arg[0] == '\0' )
+   if(  arg[0] == '\0' )
    {
       send_to_char( "Syntax: setabit <number> <description>\n\r", ch );
       send_to_char( "Syntax: setabit <number> delete\n\r", ch );
@@ -505,7 +505,7 @@ void do_setabit( CHAR_DATA * ch, char *argument )
 
 /* setqbit <number> <desc> */
 /* Set the description for a particular qbit */
-void do_setqbit( CHAR_DATA * ch, char *argument )
+void do_setqbit( CHAR_DATA * ch, const char *argument )
 {
    BIT_DATA *bit;
    int number;
@@ -513,7 +513,7 @@ void do_setqbit( CHAR_DATA * ch, char *argument )
 
    argument = one_argument( argument, arg );
 
-   if( !arg || arg[0] == '\0' )
+   if( arg[0] == '\0' )
    {
       send_to_char( "You must supply a bit number!\n\r", ch );
       return;
@@ -540,7 +540,7 @@ void do_setqbit( CHAR_DATA * ch, char *argument )
       return;
    }
 
-   if( !arg || arg[0] == '\0' )
+   if(  arg[0] == '\0' )
    {
       send_to_char( "Syntax: setqbit <number> <description>\n\r", ch );
       send_to_char( "Syntax: setqbit <number> delete\n\r", ch );
@@ -575,7 +575,7 @@ void do_setqbit( CHAR_DATA * ch, char *argument )
 }
 
 /* Imm command to toggle an abit on a character or to list the abits already on a character */
-void do_abit( CHAR_DATA * ch, char *argument )
+void do_abit( CHAR_DATA * ch, const char *argument )
 {
    BIT_DATA *bit;
    char buf[MAX_STRING_LENGTH];
@@ -583,7 +583,7 @@ void do_abit( CHAR_DATA * ch, char *argument )
 
    argument = one_argument( argument, buf );
 
-   if( !buf || buf[0] == '\0' )
+   if(  buf[0] == '\0' )
    {
       send_to_char( "Whose bits do you want to examine?\n\r", ch );
       return;
@@ -597,7 +597,7 @@ void do_abit( CHAR_DATA * ch, char *argument )
 
    argument = one_argument( argument, buf );
 
-   if( !buf || buf[0] == '\0' )
+   if(  buf[0] == '\0' )
    {
       if( !victim->first_abit )
       {
@@ -636,7 +636,7 @@ void do_abit( CHAR_DATA * ch, char *argument )
 }
 
 /* Immortal command to toggle a qbit on a character or to list the qbits already on a character */
-void do_qbit( CHAR_DATA * ch, char *argument )
+void do_qbit( CHAR_DATA * ch, const char *argument )
 {
    BIT_DATA *bit;
    CHAR_DATA *victim;
@@ -644,7 +644,7 @@ void do_qbit( CHAR_DATA * ch, char *argument )
 
    argument = one_argument( argument, buf );
 
-   if( !buf || buf[0] == '\0' )
+   if(  buf[0] == '\0' )
    {
       send_to_char( "Whose bits do you want to examine?\n\r", ch );
       return;
@@ -664,7 +664,7 @@ void do_qbit( CHAR_DATA * ch, char *argument )
 
    argument = one_argument( argument, buf );
 
-   if( !buf || buf[0] == '\0' )
+   if( buf[0] == '\0' )
    {
       if( !victim->pcdata->first_qbit )
       {
@@ -708,7 +708,7 @@ void do_qbit( CHAR_DATA * ch, char *argument )
  * be in another room. If the target will be in a different location after the prog, set the
  * bit BEFORE they move.
  */
-void do_mpaset( CHAR_DATA * ch, char *argument )
+void do_mpaset( CHAR_DATA * ch, const char *argument )
 {
    char arg1[MAX_INPUT_LENGTH];
    char arg2[MAX_INPUT_LENGTH];
@@ -724,13 +724,13 @@ void do_mpaset( CHAR_DATA * ch, char *argument )
    argument = one_argument( argument, arg1 );
    argument = one_argument( argument, arg2 );
 
-   if( !arg1 || arg1[0] == '\0' )
+   if( arg1[0] == '\0' )
    {
       progbug( "Mpaset: missing victim", ch );
       return;
    }
 
-   if( !arg2 || arg2[0] == '\0' )
+   if( arg2[0] == '\0' )
    {
       progbug( "Mpaset: missing bit", ch );
       return;
@@ -754,7 +754,7 @@ void do_mpaset( CHAR_DATA * ch, char *argument )
 /* Because this can be used on death_progs, be SURE your victim is correct or you could
  * end up setting a bit on the wrong person. Use 0.$n as your victim target in progs.
  */
-void do_mpqset( CHAR_DATA * ch, char *argument )
+void do_mpqset( CHAR_DATA * ch, const char *argument )
 {
    char arg1[MAX_INPUT_LENGTH];
    char arg2[MAX_INPUT_LENGTH];
@@ -770,13 +770,13 @@ void do_mpqset( CHAR_DATA * ch, char *argument )
    argument = one_argument( argument, arg1 );
    argument = one_argument( argument, arg2 );
 
-   if( !arg1 || arg1[0] == '\0' )
+   if( arg1[0] == '\0' )
    {
       progbug( "Mpqset: missing victim", ch );
       return;
    }
 
-   if( !arg2 || arg2[0] == '\0' )
+   if( arg2[0] == '\0' )
    {
       progbug( "Mpqset: missing bit", ch );
       return;

--- a/src/bits.h
+++ b/src/bits.h
@@ -1,0 +1,44 @@
+/* bits.h -- Abits and Qbits for the Rogue Winds by Scion
+   Copyright 2000 by Peter Keeler, All Rights Reserved. The content
+   of this file may be used by anyone for any purpose so long as this
+   original header remains entirely intact and credit is given to the
+   original author(s).
+
+   The concept for this was inspired by Mallory's mob scripting system
+   from AntaresMUD.
+
+   It is not required, but I'd appreciate hearing back from people
+   who use this code. What are you using it for, what have you done
+   to it, ideas, comments, etc. So while it's not necessary, I'd love
+   to get a note from you at scion@divineright.org. Thanks! -- Scion
+*/
+
+typedef struct bit_data BIT_DATA;
+
+#define MAX_xBITS 32000
+
+/* abit and qbit struct */
+struct bit_data
+{
+   BIT_DATA *next;
+   BIT_DATA *prev;
+   int number;
+   char desc[MAX_STRING_LENGTH];
+};
+
+extern BIT_DATA *first_abit;
+extern BIT_DATA *first_qbit;
+extern BIT_DATA *last_abit;
+extern BIT_DATA *last_qbit;
+
+BIT_DATA *get_abit( CHAR_DATA * ch, int number );
+BIT_DATA *get_qbit( CHAR_DATA * ch, int number );
+BIT_DATA *find_qbit( int number );
+BIT_DATA *find_abit( int number );
+void set_abit( CHAR_DATA *ch, int number );
+void set_qbit( CHAR_DATA *ch, int number );
+void remove_abit( CHAR_DATA *ch, int number );
+void remove_qbit( CHAR_DATA *ch, int number );
+void free_questbits( void );
+void load_bits( void );
+

--- a/src/comm.c
+++ b/src/comm.c
@@ -274,7 +274,9 @@ void cleanup_memory( void )
       UNLINK( desc, first_descriptor, last_descriptor, next, prev );
       free_desc( desc );
    }
-
+   /* Questbits */
+   fprintf( stdout, "%s", "Questbits.\n" );
+   free_questbits();
    /*
     * Liquids 
     */

--- a/src/db.c
+++ b/src/db.c
@@ -447,6 +447,12 @@ void boot_db( bool fCopyOver )
    log_string( "Loading tongues" );
    load_tongues(  );
 
+   /*
+    * abit/qbit code
+    */
+   log_string( "Loading quest bit tables" );
+   load_bits(  );
+
 //   log_string( "Making wizlist" );
 //   make_wizlist(  );
 
@@ -3032,6 +3038,7 @@ void free_char( CHAR_DATA * ch )
    AFFECT_DATA *paf;
    TIMER *timer;
    MPROG_ACT_LIST *mpact, *mpact_next;
+   BIT_DATA *abit, *abit_next;
    NOTE_DATA *comments, *comments_next;
    VARIABLE_DATA *vd, *vd_next;
 
@@ -3070,6 +3077,14 @@ void free_char( CHAR_DATA * ch )
    stop_fearing( ch );
    free_fight( ch );
 
+   for( abit = ch->first_abit; abit; abit = abit_next )
+   {
+      abit_next = abit->next;
+
+      UNLINK( abit, ch->first_abit, ch->last_abit, next, prev );
+      DISPOSE( abit );
+   }
+
    if( ch->pnote )
       free_note( ch->pnote );
 
@@ -3082,7 +3097,7 @@ void free_char( CHAR_DATA * ch )
    if( ch->pcdata )
    {
       IGNORE_DATA *temp, *next;
-
+      BIT_DATA *qbit, *qbit_next;
       if( ch->pcdata->pet )
       {
          extract_char( ch->pcdata->pet, TRUE );
@@ -3132,6 +3147,13 @@ void free_char( CHAR_DATA * ch )
                STRFREE( ch->pcdata->tell_history[i] );
          }
          DISPOSE( ch->pcdata->tell_history );
+      }
+      for( qbit = ch->pcdata->first_qbit; qbit; qbit = qbit_next )
+      {
+         qbit_next = qbit->next;
+
+         UNLINK( qbit, ch->pcdata->first_qbit, ch->pcdata->last_qbit, next, prev );
+         DISPOSE( qbit );
       }
 #ifdef IMC
       imc_freechardata( ch );

--- a/src/mud.h
+++ b/src/mud.h
@@ -383,7 +383,7 @@ struct extended_bitvector
 {
    unsigned int bits[XBI];
 };
-
+#include "bits.h"
 #include "color.h"
 #include "dns.h"
 #include "hotboot.h"
@@ -2254,6 +2254,8 @@ struct char_data
    ROOM_INDEX_DATA *in_room;
    ROOM_INDEX_DATA *was_in_room;
    PC_DATA *pcdata;
+   BIT_DATA *first_abit;  /* abit/qbit code */
+   BIT_DATA *last_abit;
    DO_FUN *last_cmd;
    DO_FUN *prev_cmd; /* mapping */
    void *dest_buf;   /* This one is to assign to differen things */
@@ -2381,6 +2383,8 @@ struct pc_data
    COUNCIL_DATA *council;
    AREA_DATA *area;
    DEITY_DATA *deity;
+   BIT_DATA *first_qbit;  /* abit/qbit code */
+   BIT_DATA *last_qbit;
    GAME_BOARD_DATA *game_board;
    NUISANCE_DATA *nuisance;   /* New Nuisance structure */
    KILLED_DATA killed[MAX_KILLTRACK];
@@ -4173,6 +4177,15 @@ DECLARE_DO_FUN( do_worth );
 DECLARE_DO_FUN( do_yell );
 DECLARE_DO_FUN( do_zap );
 DECLARE_DO_FUN( do_zones );
+/* quest bits */
+DECLARE_DO_FUN( do_showabit );
+DECLARE_DO_FUN( do_showqbit );
+DECLARE_DO_FUN( do_setabit );
+DECLARE_DO_FUN( do_setqbit );
+DECLARE_DO_FUN( do_abit );
+DECLARE_DO_FUN( do_qbit );
+DECLARE_DO_FUN( do_mpaset );
+DECLARE_DO_FUN( do_mpqset );
 
 /* mob prog stuff */
 DECLARE_DO_FUN( do_mp_close_passage );

--- a/src/mud_prog.c
+++ b/src/mud_prog.c
@@ -1014,6 +1014,45 @@ int mprog_do_ifcheck( const char *ifcheck, CHAR_DATA * mob, CHAR_DATA * actor, O
          }
          return IS_AFFECTED( chkchar, value ) ? TRUE : FALSE;
       }
+      /*
+       * abits and qbits 
+       */
+      if( !str_cmp( chck, "hasabit" ) )
+      {
+         int number;
+
+         if( is_number( rval ) )
+         {
+            number = atoi( rval );
+
+            if( get_abit( chkchar, number ) == NULL )
+               return mprog_veval( 0, opr, 1, mob );
+            else
+               return mprog_veval( 1, opr, 1, mob );
+         }
+         progbug( "hasabit: bad abit number", mob );
+         return BERR;
+      }
+
+      /*
+       * abits and qbits 
+       */
+      if( !str_cmp( chck, "hasqbit" ) )
+      {
+         int number;
+
+         if( is_number( rval ) )
+         {
+            number = atoi( rval );
+
+            if( get_qbit( chkchar, number ) == NULL )
+               return mprog_veval( 0, opr, 1, mob );
+            else
+               return mprog_veval( 1, opr, 1, mob );
+         }
+         progbug( "hasqbit: bad qbit number", mob );
+         return BERR;
+      }
       if( !str_cmp( chck, "numfighting" ) )
       {
          return mprog_veval( chkchar->num_fighting - 1, opr, atoi( rval ), mob );


### PR DESCRIPTION
Note:  abits are temporary, qbits are saved.  abits can be used for tasks in order to complete a quest. Qbits are used to track completed quests.  eg. if you are trying to kill 20 nagas, and logout.. you will have to kill 20 nagas again when you login... yet if you complete the quest, then qbit will be set that you have completed it.

You must cedit the following commands to the command table:
abit
qbit
showabit
showqbit
setabit
setqbit
mpaset
mpqset


attached is the included helpfile:




To create a new abit or qbit, use the setabit and setqbit commands:
setabit <number> <description>
setqbit <number> <description>

The range for numbers is from 0 to 32000, and is defined as MAX_xBITS
just above the struct in mud.h. To raise or lower it, change the #define
and recompile your mud.

To see what bits exist, use the showabit and showqbit commands.
showabit <number>   /* Show the abit at <number> */
showqbit <number>   /* Show the qbit at <number> */
showabit all        /* List all abits */
showqbit all        /* List all qbits */

To set abits or qbits on characters manually, or see which ones characters have
on
them, use the abit and qbit commands:
abit <victim> [number]
qbit <victim> [number]

Without an argument, they'll list the bits, with an argument, they'll toggle the
bit
on or off.

Mob progs can use mpaset and mpqset to toggle bits on or off:
mpaset <victim> <number>
mpqset <victim> <number>

Mob progs can also use the hasabit and hasqbit ifchecks to check the
state of a bit on a character. Example:

if hasabit($n) == 3100
say Welcome back, $n.
else
say You're new around here, aren't you, $n?
mpaset $n 3100
endif

They can also check for a bit being turned off. Example:

if hasqbit($n) != 8546
say Haven't you completed your quest yet, $n?
else
say Congratulations, $n! You've completed the quest!
endif
